### PR TITLE
Preserve the URL QueryString from anchor tags

### DIFF
--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -27,7 +27,7 @@ export function ensureAnchorHistory () {
 		}
 
 		// Remove the origin from the start of the HREF to get the path
-		const path = $anchor.pathname;
+		const path = `${$anchor.pathname}${$anchor.search}`;
 
 		// Prevent the default behavior
 		e.preventDefault();


### PR DESCRIPTION
Anchor tag query strings were getting stripped after being clicked so this preserves them.