### PR TITLE
Add Node 14 build support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,57 +88,49 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.8.3"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
-			"integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.9.1",
-				"invariant": "^2.2.4",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==",
+			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+			"integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.12.10",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helpers": "^7.12.5",
+				"@babel/parser": "^7.12.10",
+				"@babel/template": "^7.12.7",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.10",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
+				"lodash": "^4.17.19",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -148,46 +140,44 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.9.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.3.tgz",
-			"integrity": "sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.9.0",
+				"@babel/types": "^7.12.11",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
-			"integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.10"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
-			"integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-explode-assignable-expression": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
-			"integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
+			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.6",
-				"browserslist": "^4.9.1",
-				"invariant": "^2.2.4",
-				"levenary": "^1.1.1",
+				"@babel/compat-data": "^7.12.5",
+				"@babel/helper-validator-option": "^7.12.1",
+				"browserslist": "^4.14.5",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -199,204 +189,236 @@
 				}
 			}
 		},
-		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
-			"integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-regex": "^7.8.3",
-				"regexpu-core": "^4.7.0"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+			"integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"regexpu-core": "^4.7.1"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
-			"integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+			"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/types": "^7.8.3",
-				"lodash": "^4.17.13"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
-			"integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+			"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-			"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+			"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-get-function-arity": "^7.12.10",
+				"@babel/template": "^7.12.7",
+				"@babel/types": "^7.12.11"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+			"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.10"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
-			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.5"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-simple-access": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.6",
-				"@babel/types": "^7.9.0",
-				"lodash": "^4.17.13"
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+			"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.10"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
 			"dev": true
 		},
-		"@babel/helper-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
-			"integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.13"
-			}
-		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
-			"integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-wrap-function": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-wrap-function": "^7.10.4",
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/helper-member-expression-to-functions": "^7.12.7",
+				"@babel/helper-optimise-call-expression": "^7.12.10",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.11"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.12.11"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-			"integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+			"dev": true
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==",
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
-			"integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+			"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0"
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -439,100 +461,142 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.9.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.3.tgz",
-			"integrity": "sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
-			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
+			"integrity": "sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-remap-async-to-generator": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1",
 				"@babel/plugin-syntax-async-generators": "^7.8.0"
 			}
 		},
-		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
-			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
 			}
 		},
-		"@babel/plugin-proposal-json-strings": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
-			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+		"@babel/plugin-proposal-export-namespace-from": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+			"integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.0"
 			}
 		},
-		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
-			"integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+		"@babel/plugin-proposal-logical-assignment-operators": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+			"integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+			"integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
-			"integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
-			"integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+			"integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-transform-parameters": "^7.12.1"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
-			"integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+			"integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
-			"integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+			"integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
 			}
 		},
-		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
-			"integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
+		"@babel/plugin-proposal-private-methods": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+			"integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.8",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+			"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -544,6 +608,15 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
 		"@babel/plugin-syntax-dynamic-import": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
@@ -553,6 +626,15 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-export-namespace-from": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
 		"@babel/plugin-syntax-json-strings": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -560,6 +642,15 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -572,12 +663,12 @@
 			}
 		},
 		"@babel/plugin-syntax-numeric-separator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
-			"integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
@@ -608,272 +699,270 @@
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
-			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
-			"integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+			"integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
-			"integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-remap-async-to-generator": "^7.8.3"
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
-			"integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+			"integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
-			"integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
+			"integrity": "sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"lodash": "^4.17.13"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz",
-			"integrity": "sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+			"integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-define-map": "^7.8.3",
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-define-map": "^7.10.4",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
-			"integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+			"integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
-			"integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+			"integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
-			"integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+			"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
-			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
-			"integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+			"integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
-			"integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+			"integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
-			"integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+			"integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
-			"integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+			"integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
-			"integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+			"integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
-			"integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
-			"integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+			"integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-simple-access": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-simple-access": "^7.12.1",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
-			"integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.8.3",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-hoist-variables": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
-			"integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
-			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
-			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
-			"integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+			"integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.9.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz",
-			"integrity": "sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+			"integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
-			"integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+			"integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
-			"integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+			"integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.2"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
-			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
-			"integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.10.tgz",
+			"integrity": "sha512-xOrUfzPxw7+WDm9igMgQCbO3cJKymX7dFdsgRr1eu9n3KjjyU4pptIXbXPseQDquw+W+RuJEJMHKHNsPNNm3CA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"resolve": "^1.8.1",
+				"@babel/helper-module-imports": "^7.12.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"semver": "^5.5.1"
 			},
 			"dependencies": {
@@ -886,127 +975,141 @@
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
-			"integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+			"integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
-			"integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+			"integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
-			"integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+			"integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-regex": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
-			"integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+			"integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
-			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+			"integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+			"integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
-			"integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+			"integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
-			"integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.9.0",
-				"@babel/helper-compilation-targets": "^7.8.7",
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
-				"@babel/plugin-proposal-json-strings": "^7.8.3",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.9.0",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/compat-data": "^7.12.7",
+				"@babel/helper-compilation-targets": "^7.12.5",
+				"@babel/helper-module-imports": "^7.12.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.11",
+				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+				"@babel/plugin-proposal-class-properties": "^7.12.1",
+				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+				"@babel/plugin-proposal-json-strings": "^7.12.1",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.7",
+				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.7",
+				"@babel/plugin-proposal-private-methods": "^7.12.1",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
 				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-class-properties": "^7.12.1",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
 				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3",
-				"@babel/plugin-transform-arrow-functions": "^7.8.3",
-				"@babel/plugin-transform-async-to-generator": "^7.8.3",
-				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-				"@babel/plugin-transform-block-scoping": "^7.8.3",
-				"@babel/plugin-transform-classes": "^7.9.0",
-				"@babel/plugin-transform-computed-properties": "^7.8.3",
-				"@babel/plugin-transform-destructuring": "^7.8.3",
-				"@babel/plugin-transform-dotall-regex": "^7.8.3",
-				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
-				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-				"@babel/plugin-transform-for-of": "^7.9.0",
-				"@babel/plugin-transform-function-name": "^7.8.3",
-				"@babel/plugin-transform-literals": "^7.8.3",
-				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
-				"@babel/plugin-transform-modules-amd": "^7.9.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.9.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.9.0",
-				"@babel/plugin-transform-modules-umd": "^7.9.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-				"@babel/plugin-transform-new-target": "^7.8.3",
-				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.8.7",
-				"@babel/plugin-transform-property-literals": "^7.8.3",
-				"@babel/plugin-transform-regenerator": "^7.8.7",
-				"@babel/plugin-transform-reserved-words": "^7.8.3",
-				"@babel/plugin-transform-shorthand-properties": "^7.8.3",
-				"@babel/plugin-transform-spread": "^7.8.3",
-				"@babel/plugin-transform-sticky-regex": "^7.8.3",
-				"@babel/plugin-transform-template-literals": "^7.8.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
-				"@babel/plugin-transform-unicode-regex": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.12.1",
+				"@babel/plugin-transform-arrow-functions": "^7.12.1",
+				"@babel/plugin-transform-async-to-generator": "^7.12.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.11",
+				"@babel/plugin-transform-classes": "^7.12.1",
+				"@babel/plugin-transform-computed-properties": "^7.12.1",
+				"@babel/plugin-transform-destructuring": "^7.12.1",
+				"@babel/plugin-transform-dotall-regex": "^7.12.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.12.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+				"@babel/plugin-transform-for-of": "^7.12.1",
+				"@babel/plugin-transform-function-name": "^7.12.1",
+				"@babel/plugin-transform-literals": "^7.12.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.12.1",
+				"@babel/plugin-transform-modules-amd": "^7.12.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.12.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.12.1",
+				"@babel/plugin-transform-modules-umd": "^7.12.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+				"@babel/plugin-transform-new-target": "^7.12.1",
+				"@babel/plugin-transform-object-super": "^7.12.1",
+				"@babel/plugin-transform-parameters": "^7.12.1",
+				"@babel/plugin-transform-property-literals": "^7.12.1",
+				"@babel/plugin-transform-regenerator": "^7.12.1",
+				"@babel/plugin-transform-reserved-words": "^7.12.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.12.1",
+				"@babel/plugin-transform-spread": "^7.12.1",
+				"@babel/plugin-transform-sticky-regex": "^7.12.7",
+				"@babel/plugin-transform-template-literals": "^7.12.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.10",
+				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
+				"@babel/plugin-transform-unicode-regex": "^7.12.1",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.9.0",
-				"browserslist": "^4.9.1",
-				"core-js-compat": "^3.6.2",
-				"invariant": "^2.2.2",
-				"levenary": "^1.1.1",
+				"@babel/types": "^7.12.11",
+				"core-js-compat": "^3.8.0",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -1019,9 +1122,9 @@
 			}
 		},
 		"@babel/preset-modules": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-			"integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1032,51 +1135,67 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/template": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-			"integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+			"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.12.11",
+				"@babel/generator": "^7.12.11",
+				"@babel/helper-function-name": "^7.12.11",
+				"@babel/helper-split-export-declaration": "^7.12.11",
+				"@babel/parser": "^7.12.11",
+				"@babel/types": "^7.12.12",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-			"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+			"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.0",
-				"lodash": "^4.17.13",
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"@csstools/convert-colors": {
@@ -1128,6 +1247,15 @@
 			"dev": true,
 			"requires": {
 				"@hapi/hoek": "^8.3.0"
+			}
+		},
+		"@mdn/browser-compat-data": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz",
+			"integrity": "sha512-GeeM827DlzFFidn1eKkMBiqXFD2oLsnZbaiGhByPl0vcapsRzUL+t9hDoov1swc9rB2jw64R+ihtzC8qOE9wXw==",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.2"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -1202,13 +1330,32 @@
 			}
 		},
 		"@rollup/plugin-replace": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.1.tgz",
-			"integrity": "sha512-qDcXj2VOa5+j0iudjb+LiwZHvBRRgWbHPhRmo1qde2KItTjuxDVQO21rp9/jOlzKR5YO0EsgRQoyox7fnL7y/A==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz",
+			"integrity": "sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^3.0.4",
-				"magic-string": "^0.25.5"
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+					"dev": true
+				}
 			}
 		},
 		"@rollup/pluginutils": {
@@ -1227,9 +1374,9 @@
 			"dev": true
 		},
 		"@surma/rollup-plugin-off-main-thread": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.1.tgz",
-			"integrity": "sha512-ZPBWYQDdO4JZiTmTP3DABsHhIPA7bEJk9Znk7tZsrbPGanoGo8YxMv//WLx5Cvb+lRgS42+6yiOIYYHCKDmkpQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz",
+			"integrity": "sha512-yBMPqmd1yEJo/280PAMkychuaALyQ9Lkb5q1ck3mjJrFuEobIfhnQ4J3mbvBoISmR3SWMWV+cGB/I0lCQee79A==",
 			"dev": true,
 			"requires": {
 				"ejs": "^2.6.1",
@@ -1246,9 +1393,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
+			"version": "7.1.12",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+			"integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -1259,18 +1406,18 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+			"integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -1278,18 +1425,18 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
-			"integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.0.tgz",
+			"integrity": "sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
 		},
 		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
+			"integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
 			"dev": true
 		},
 		"@types/color-name": {
@@ -1305,9 +1452,9 @@
 			"dev": true
 		},
 		"@types/estree": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"version": "0.0.46",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+			"integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
 			"dev": true
 		},
 		"@types/events": {
@@ -1328,9 +1475,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -1358,9 +1505,9 @@
 			"dev": true
 		},
 		"@types/q": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
-			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
+			"integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -1373,60 +1520,57 @@
 			}
 		},
 		"@types/semver": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
-			"integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+			"dev": true
 		},
 		"@types/ua-parser-js": {
-			"version": "0.7.33",
-			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-			"integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+			"version": "0.7.35",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+			"integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz",
-			"integrity": "sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==",
+			"version": "2.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
+			"integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "2.24.0",
-				"eslint-utils": "^1.4.3",
+				"@typescript-eslint/experimental-utils": "2.34.0",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
 				"tsutils": "^3.17.1"
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz",
-			"integrity": "sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==",
+			"version": "2.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+			"integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.24.0",
-				"eslint-scope": "^5.0.0"
+				"@typescript-eslint/typescript-estree": "2.34.0",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.24.0.tgz",
-			"integrity": "sha512-H2Y7uacwSSg8IbVxdYExSI3T7uM1DzmOn2COGtCahCC3g8YtM1xYAPi2MAHyfPs61VKxP/J/UiSctcRgw4G8aw==",
+			"version": "2.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
+			"integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.24.0",
-				"@typescript-eslint/typescript-estree": "2.24.0",
+				"@typescript-eslint/experimental-utils": "2.34.0",
+				"@typescript-eslint/typescript-estree": "2.34.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz",
-			"integrity": "sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==",
+			"version": "2.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+			"integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
@@ -1434,72 +1578,91 @@
 				"glob": "^7.1.6",
 				"is-glob": "^4.0.1",
 				"lodash": "^4.17.15",
-				"semver": "^6.3.0",
+				"semver": "^7.3.2",
 				"tsutils": "^3.17.1"
 			}
 		},
 		"@wessberg/browserslist-generator": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/@wessberg/browserslist-generator/-/browserslist-generator-1.0.34.tgz",
-			"integrity": "sha512-2O5wofJ9K3jus7e311O0KDNnHFGq5nFuvL4b7v7ak3cXAovPoPJTfWdWDYhT8aKM/Iy3J4+wBuJkR9SPoLwOXg==",
+			"version": "1.0.42",
+			"resolved": "https://registry.npmjs.org/@wessberg/browserslist-generator/-/browserslist-generator-1.0.42.tgz",
+			"integrity": "sha512-d7fHVGNbpMFhrwyiQrXlbmjtpmgKI3y0ns+THQNjA1exk6TY8tb6ZmUYn8KVXdCRjZUsvjedNpev/FO8OTTSyQ==",
 			"dev": true,
 			"requires": {
+				"@mdn/browser-compat-data": "^2.0.5",
 				"@types/object-path": "^0.11.0",
-				"@types/semver": "^7.1.0",
+				"@types/semver": "^7.3.4",
 				"@types/ua-parser-js": "^0.7.33",
-				"browserslist": "4.9.1",
-				"caniuse-lite": "^1.0.30001031",
-				"mdn-browser-compat-data": "1.0.10",
-				"object-path": "^0.11.4",
-				"semver": "^7.1.3",
-				"ua-parser-js": "^0.7.21"
+				"browserslist": "4.14.6",
+				"caniuse-lite": "^1.0.30001156",
+				"object-path": "^0.11.5",
+				"semver": "^7.3.2",
+				"ua-parser-js": "^0.7.22"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.9.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-					"integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+					"version": "4.14.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
+					"integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001030",
-						"electron-to-chromium": "^1.3.363",
-						"node-releases": "^1.1.50"
+						"caniuse-lite": "^1.0.30001154",
+						"electron-to-chromium": "^1.3.585",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.65"
 					}
-				},
-				"semver": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-					"integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
-					"dev": true
 				}
 			}
 		},
 		"@wessberg/rollup-plugin-ts": {
-			"version": "1.2.21",
-			"resolved": "https://registry.npmjs.org/@wessberg/rollup-plugin-ts/-/rollup-plugin-ts-1.2.21.tgz",
-			"integrity": "sha512-2wfFhfmCqLEw5mseOI/LdmFRT+AdTTfOncURVGUWbUx7XxOHJrCb466QJvJc3UcHTkyjxHhvNeaaeviuKdF1wA==",
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/@wessberg/rollup-plugin-ts/-/rollup-plugin-ts-1.3.8.tgz",
+			"integrity": "sha512-mqAk8CS5VbeE1eMRwbBkrVWqrqDxRJEWfxPHFyncsoamoazZ7iJ4Fke7tYBki+x25dw0rkN6l3VgtICM7o//cw==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.8.7",
-				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-				"@babel/plugin-proposal-json-strings": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/core": "^7.12.3",
+				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+				"@babel/plugin-proposal-json-strings": "^7.12.1",
+				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-				"@babel/plugin-transform-runtime": "^7.8.3",
-				"@babel/preset-env": "^7.8.7",
-				"@babel/runtime": "^7.8.7",
-				"@rollup/pluginutils": "^3.0.8",
-				"@types/babel__core": "^7.1.6",
-				"@wessberg/browserslist-generator": "^1.0.34",
+				"@babel/plugin-transform-runtime": "^7.12.1",
+				"@babel/preset-env": "^7.12.1",
+				"@babel/runtime": "^7.12.5",
+				"@rollup/pluginutils": "^4.1.0",
+				"@types/babel__core": "^7.1.12",
+				"@wessberg/browserslist-generator": "^1.0.42",
 				"@wessberg/stringutil": "^1.0.19",
-				"@wessberg/ts-clone-node": "^0.3.4",
-				"browserslist": "^4.9.1",
-				"chalk": "^3.0.0",
+				"@wessberg/ts-clone-node": "^0.3.18",
+				"browserslist": "^4.14.6",
+				"chalk": "^4.1.0",
 				"magic-string": "^0.25.7",
 				"slash": "^3.0.0",
-				"tslib": "^1.11.1"
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
+					"integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+					"dev": true
+				},
+				"tslib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+					"dev": true
+				}
 			}
 		},
 		"@wessberg/stringutil": {
@@ -1509,9 +1672,9 @@
 			"dev": true
 		},
 		"@wessberg/ts-clone-node": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@wessberg/ts-clone-node/-/ts-clone-node-0.3.4.tgz",
-			"integrity": "sha512-/JWk3eBbE/Og/42DNdwiWX7YhPPiPvoI5ZxW9xXsy9poRNH55gd4bwsJTNZSkgjmkv5xzq39JNZWQ2+MqfskkA==",
+			"version": "0.3.18",
+			"resolved": "https://registry.npmjs.org/@wessberg/ts-clone-node/-/ts-clone-node-0.3.18.tgz",
+			"integrity": "sha512-m/QAPt9K7w5+zmiDJbKxFeIzr6hMuo8euLwYxhj7ipRsyLB2AeAu2/6AF21s45hDXdWsaFwSed3F9R6STMrECg==",
 			"dev": true
 		},
 		"abbrev": {
@@ -1531,15 +1694,15 @@
 			}
 		},
 		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true
 		},
 		"acorn-jsx": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
 			"dev": true
 		},
 		"after": {
@@ -1549,9 +1712,9 @@
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -1804,55 +1967,18 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "9.7.4",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
-			"integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
+			"version": "9.8.6",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
+			"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.3",
-				"caniuse-lite": "^1.0.30001020",
-				"chalk": "^2.4.2",
+				"browserslist": "^4.12.0",
+				"caniuse-lite": "^1.0.30001109",
+				"colorette": "^1.2.1",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.26",
-				"postcss-value-parser": "^4.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				}
+				"postcss": "^7.0.32",
+				"postcss-value-parser": "^4.1.0"
 			}
 		},
 		"aws-sign2": {
@@ -1862,19 +1988,68 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
+		"babel-extract-comments": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+			"integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
+			"dev": true,
+			"requires": {
+				"babylon": "^6.18.0"
+			}
+		},
 		"babel-plugin-dynamic-import-node": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
 			"dev": true,
 			"requires": {
 				"object.assign": "^4.1.0"
 			}
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
+		},
+		"babel-plugin-transform-object-rest-spread": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+					"dev": true
+				}
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"backo2": {
 			"version": "1.0.2",
@@ -1950,9 +2125,9 @@
 			"dev": true
 		},
 		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"dev": true
 		},
 		"base64id": {
@@ -1980,15 +2155,15 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -2071,6 +2246,33 @@
 				"term-size": "^2.1.0",
 				"type-fest": "^0.8.1",
 				"widest-line": "^3.1.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"brace-expansion": {
@@ -2108,15 +2310,16 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz",
-			"integrity": "sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==",
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+			"integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001035",
-				"electron-to-chromium": "^1.3.378",
-				"node-releases": "^1.1.52",
-				"pkg-up": "^3.1.0"
+				"caniuse-lite": "^1.0.30001173",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.634",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.69"
 			}
 		},
 		"buffer-alloc": {
@@ -2148,9 +2351,9 @@
 			"dev": true
 		},
 		"builtin-modules": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
 			"dev": true
 		},
 		"bytes": {
@@ -2206,6 +2409,16 @@
 					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 					"dev": true
 				}
+			}
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"call-me-maybe": {
@@ -2291,9 +2504,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001035",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-			"integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==",
+			"version": "1.0.30001174",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001174.tgz",
+			"integrity": "sha512-tqClL/4ThQq6cfFXH3oJL4rifFBeM6gTkphjao5kgwMaW9yn0tKgQLAEfKzDwj6HQWCB/aWo8kTFlSvIN8geEA==",
 			"dev": true
 		},
 		"caseless": {
@@ -2317,9 +2530,9 @@
 			}
 		},
 		"chalk": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
@@ -2333,9 +2546,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -2368,19 +2581,19 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-			"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
+			"integrity": "sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
+				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.3.0"
+				"readdirp": "~3.5.0"
 			}
 		},
 		"chownr": {
@@ -2430,9 +2643,9 @@
 			}
 		},
 		"cli-boxes": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
 			"dev": true
 		},
 		"cli-cursor": {
@@ -2445,9 +2658,9 @@
 			}
 		},
 		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
 			"dev": true
 		},
 		"cliui": {
@@ -2535,13 +2748,13 @@
 			}
 		},
 		"color": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
-			"integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
+			"integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-string": "^1.5.4"
 			},
 			"dependencies": {
 				"color-convert": {
@@ -2577,14 +2790,20 @@
 			"dev": true
 		},
 		"color-string": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+			"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
 			"dev": true,
 			"requires": {
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
 			}
+		},
+		"colorette": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+			"dev": true
 		},
 		"colors": {
 			"version": "1.4.0",
@@ -2705,13 +2924,19 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
+		"core-js": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"dev": true
+		},
 		"core-js-compat": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
-			"integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.2.tgz",
+			"integrity": "sha512-LO8uL9lOIyRRrQmZxHZFl1RV+ZbcsAkFWTktn5SmH40WgLtSNYN4m4W2v9ONT147PxBY/XrRhrWq8TlvObyUjQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.3",
+				"browserslist": "^4.16.0",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -2868,9 +3093,9 @@
 			}
 		},
 		"css-what": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
-			"integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
 			"dev": true
 		},
 		"cssdb": {
@@ -2963,12 +3188,36 @@
 			"dev": true
 		},
 		"csso": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
-			"integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+			"integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
 			"dev": true,
 			"requires": {
-				"css-tree": "1.0.0-alpha.37"
+				"css-tree": "^1.1.2"
+			},
+			"dependencies": {
+				"css-tree": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
+					"integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "2.0.14",
+						"source-map": "^0.6.1"
+					}
+				},
+				"mdn-data": {
+					"version": "2.0.14",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+					"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"currently-unhandled": {
@@ -3008,12 +3257,12 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -3141,14 +3390,6 @@
 				"leven": "^2.0.0",
 				"lodash.deburr": "^4.1.0",
 				"ramda": "^0.26.1"
-			},
-			"dependencies": {
-				"leven": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-					"dev": true
-				}
 			}
 		},
 		"diff": {
@@ -3189,9 +3430,9 @@
 			},
 			"dependencies": {
 				"domelementtype": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+					"integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
 					"dev": true
 				}
 			}
@@ -3213,18 +3454,18 @@
 			}
 		},
 		"dot-prop": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
 		},
 		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
 		"duplexer3": {
@@ -3256,9 +3497,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.380",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.380.tgz",
-			"integrity": "sha512-2jhQxJKcjcSpVOQm0NAfuLq8o+130blrcawoumdXT6411xG/xIAOyZodO/y7WTaYlz/NHe3sCCAe/cJLnDsqTw==",
+			"version": "1.3.637",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.637.tgz",
+			"integrity": "sha512-924WXYMYquYybc+7pNApGlhY2RWg3MY3he4BrZ5BUmM2n1MGBsrS+PZxrlo6UAsWuNl4NE66fqFdwsWkBUGgkA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -3369,9 +3610,9 @@
 			"dev": true
 		},
 		"entities": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
 			"dev": true
 		},
 		"error-ex": {
@@ -3384,22 +3625,23 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.18.0-next.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+			"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
+				"is-callable": "^1.2.2",
+				"is-negative-zero": "^2.0.0",
+				"is-regex": "^1.1.1",
+				"object-inspect": "^1.8.0",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"object.assign": "^4.1.1",
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -3412,6 +3654,12 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true
 		},
 		"escape-goat": {
 			"version": "2.1.1",
@@ -3432,9 +3680,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
@@ -3539,6 +3787,15 @@
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
+				"eslint-utils": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+					"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -3549,9 +3806,9 @@
 					}
 				},
 				"import-fresh": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 					"dev": true,
 					"requires": {
 						"parent-module": "^1.0.0",
@@ -3570,6 +3827,12 @@
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"strip-ansi": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -3582,37 +3845,37 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
-			"integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+			"integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
 			}
 		},
 		"eslint-scope": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-			"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
+				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
 		"espree": {
@@ -3633,21 +3896,37 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "^5.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
 			}
 		},
 		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
 			}
 		},
 		"estraverse": {
@@ -3669,9 +3948,9 @@
 			"dev": true
 		},
 		"eventemitter3": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
 			"dev": true
 		},
 		"expand-brackets": {
@@ -3834,9 +4113,9 @@
 			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"fast-glob": {
@@ -3950,9 +4229,9 @@
 			}
 		},
 		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+			"integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
 			"dev": true,
 			"requires": {
 				"is-buffer": "~2.0.3"
@@ -3970,9 +4249,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
 		"flatten": {
@@ -3982,24 +4261,10 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
-			"integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+			"integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -4064,9 +4329,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+			"integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
 			"dev": true,
 			"optional": true
 		},
@@ -4157,9 +4422,9 @@
 			}
 		},
 		"gensync": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true
 		},
 		"get-caller-file": {
@@ -4173,6 +4438,17 @@
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
 		},
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.2",
@@ -4246,13 +4522,13 @@
 			"dev": true
 		},
 		"globule": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
-			"integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+			"integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.12",
+				"lodash": "~4.17.10",
 				"minimatch": "~3.0.2"
 			}
 		},
@@ -4304,12 +4580,12 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -4517,9 +4793,9 @@
 			}
 		},
 		"http-proxy": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
 			"dev": true,
 			"requires": {
 				"eventemitter3": "^4.0.0",
@@ -4613,40 +4889,33 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+			"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
+				"chalk": "^4.1.0",
 				"cli-cursor": "^3.1.0",
-				"cli-width": "^2.0.0",
+				"cli-width": "^3.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"mute-stream": "0.0.8",
 				"run-async": "^2.4.0",
-				"rxjs": "^6.5.3",
+				"rxjs": "^6.6.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0",
 				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
-		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -4696,15 +4965,15 @@
 			}
 		},
 		"is-buffer": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
 			"dev": true
 		},
 		"is-color-stop": {
@@ -4719,6 +4988,15 @@
 				"hsla-regex": "^1.0.0",
 				"rgb-regex": "^1.0.1",
 				"rgba-regex": "^1.0.0"
+			}
+		},
+		"is-core-module": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -4817,6 +5095,12 @@
 			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
 			"dev": true
 		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4838,28 +5122,22 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
-		},
 		"is-reference": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
-			"integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
 			"dev": true,
 			"requires": {
-				"@types/estree": "0.0.39"
+				"@types/estree": "*"
 			}
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-regexp": {
@@ -4980,9 +5258,9 @@
 			}
 		},
 		"js-base64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
-			"integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -4992,9 +5270,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -5050,9 +5328,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-			"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
@@ -5165,9 +5443,9 @@
 			}
 		},
 		"karma-rollup-preprocessor": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.3.tgz",
-			"integrity": "sha512-a+58BcQy7B8csCdLhsK6rPZ+zhB0zTeEG/tlOe8HkL66PuJ+hELaiheATD1ntR97tsFB1kQpDzfXOv//QjHuMg==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.5.tgz",
+			"integrity": "sha512-VhZI81l8LZBvBrSf4xaojsbur7bcycsSlxXkYaTOjV6DQwx1gtAM0CQVdue7LuIbXB1AohYIg0S5at+dqDtMxQ==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^3.3.1",
@@ -5189,29 +5467,11 @@
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
-		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
-			"requires": {
-				"invert-kv": "^1.0.0"
-			}
-		},
 		"leven": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
 			"dev": true
-		},
-		"levenary": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
-			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-			"dev": true,
-			"requires": {
-				"leven": "^3.1.0"
-			}
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -5436,9 +5696,9 @@
 					},
 					"dependencies": {
 						"@nodelib/fs.stat": {
-							"version": "2.0.3",
-							"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-							"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+							"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
 							"dev": true
 						},
 						"braces": {
@@ -5451,9 +5711,9 @@
 							}
 						},
 						"fast-glob": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-							"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+							"version": "3.2.4",
+							"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+							"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
 							"dev": true,
 							"requires": {
 								"@nodelib/fs.stat": "^2.0.2",
@@ -5550,9 +5810,9 @@
 			}
 		},
 		"livereload-js": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-3.2.2.tgz",
-			"integrity": "sha512-xhScbNeC687ZINjEf/bD+BMiPx4s4q0mehcLb3zCc8+mykOtmaBR4vqzyIV9rIGdG9JjHaT0LiFdscvivCjX1Q==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-3.3.1.tgz",
+			"integrity": "sha512-CBu1gTEfzVhlOK1WASKAAJ9Qx1fHECTq0SUB67sfxwQssopTyvzqTlgl+c0h9pZ6V+Fzd2rc510ppuNusg9teQ==",
 			"dev": true
 		},
 		"load-json-file": {
@@ -5702,15 +5962,6 @@
 				"streamroller": "^1.0.6"
 			}
 		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -5734,13 +5985,12 @@
 			"dev": true
 		},
 		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"magic-string": {
@@ -5780,15 +6030,6 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"mdn-browser-compat-data": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.10.tgz",
-			"integrity": "sha512-UusipwyfBuSYQ9+bJXCuLXRg1rPVZic3RSGKtMHPGNFAdIOvXKOrZ9pAN+4udGVW17QOZuR73NpV95BmUfWHxw==",
-			"dev": true,
-			"requires": {
-				"extend": "3.0.2"
 			}
 		},
 		"mdn-data": {
@@ -5863,24 +6104,24 @@
 			}
 		},
 		"mime": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+			"integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.26",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"version": "2.1.28",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.43.0"
+				"mime-db": "1.45.0"
 			}
 		},
 		"mimic-fn": {
@@ -5932,18 +6173,18 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-			"integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
 		},
 		"mocha": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-			"integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+			"integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "3.2.3",
@@ -5959,7 +6200,7 @@
 				"js-yaml": "3.13.1",
 				"log-symbols": "3.0.0",
 				"minimatch": "3.0.4",
-				"mkdirp": "0.5.3",
+				"mkdirp": "0.5.5",
 				"ms": "2.1.1",
 				"node-environment-flags": "1.0.6",
 				"object.assign": "4.1.0",
@@ -6053,6 +6294,13 @@
 						"locate-path": "^3.0.0"
 					}
 				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"dev": true,
+					"optional": true
+				},
 				"glob": {
 					"version": "7.1.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -6073,6 +6321,16 @@
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -6088,6 +6346,18 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+					"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.2",
+						"function-bind": "^1.1.1",
+						"has-symbols": "^1.0.0",
+						"object-keys": "^1.0.11"
+					}
 				},
 				"p-locate": {
 					"version": "3.0.0",
@@ -6208,9 +6478,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
 			"dev": true
 		},
 		"nanoid": {
@@ -6312,18 +6582,15 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.52",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-			"integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-			"dev": true,
-			"requires": {
-				"semver": "^6.3.0"
-			}
+			"version": "1.1.69",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
+			"integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
+			"dev": true
 		},
 		"node-sass": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-			"integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+			"integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -6340,7 +6607,7 @@
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
 				"request": "^2.88.0",
-				"sass-graph": "^2.2.4",
+				"sass-graph": "2.2.5",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
 			},
@@ -6386,6 +6653,16 @@
 					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
 					"dev": true
 				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -6399,6 +6676,12 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				}
 			}
@@ -6550,9 +6833,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -6562,9 +6845,9 @@
 			"dev": true
 		},
 		"object-path": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-			"integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=",
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+			"integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==",
 			"dev": true
 		},
 		"object-visit": {
@@ -6577,25 +6860,26 @@
 			}
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+			"integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
+				"es-abstract": "^1.18.0-next.1"
 			}
 		},
 		"object.pick": {
@@ -6608,14 +6892,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+			"integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
+				"es-abstract": "^1.18.0-next.1",
 				"has": "^1.0.3"
 			}
 		},
@@ -6638,9 +6922,9 @@
 			}
 		},
 		"onetime": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
@@ -6664,9 +6948,9 @@
 			}
 		},
 		"opener": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
 			"dev": true
 		},
 		"optimist": {
@@ -6702,9 +6986,9 @@
 			}
 		},
 		"opts": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/opts/-/opts-1.2.7.tgz",
-			"integrity": "sha512-hwZhzGGG/GQ7igxAVFOEun2N4fWul31qE9nfBdCnZGQCB5+L7tN9xZ+94B4aUpLOJx/of3zZs5XsuubayQYQjA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
+			"integrity": "sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==",
 			"dev": true
 		},
 		"os-homedir": {
@@ -6712,15 +6996,6 @@
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
-		},
-		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"dev": true,
-			"requires": {
-				"lcid": "^1.0.0"
-			}
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
@@ -6966,51 +7241,6 @@
 				"pinkie": "^2.0.0"
 			}
 		},
-		"pkg-up": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-			"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-			"dev": true,
-			"requires": {
-				"find-up": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
-			}
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -7018,9 +7248,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.27",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
-			"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+			"version": "7.0.35",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+			"integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -7192,9 +7422,9 @@
 			}
 		},
 		"postcss-calc": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.2.tgz",
-			"integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+			"integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.27",
@@ -7509,9 +7739,9 @@
 			}
 		},
 		"postcss-font-variant": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
-			"integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.1.tgz",
+			"integrity": "sha512-I3ADQSTNtLTTd8uxZhtSOrTCQ9G4qUVKPjHiDk0bV75QSxXjVWiJVJ2VLdspGUi9fbW9BcjKJoRvxAH1pckqmA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.2"
@@ -7708,12 +7938,12 @@
 			}
 		},
 		"postcss-nested": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.1.tgz",
-			"integrity": "sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
+			"integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.21",
+				"postcss": "^7.0.32",
 				"postcss-selector-parser": "^6.0.2"
 			}
 		},
@@ -8198,9 +8428,9 @@
 			}
 		},
 		"postcss-selector-not": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
-			"integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.1.tgz",
+			"integrity": "sha512-YolvBgInEK5/79C+bdFMyzqTg6pkYqDbzZIST/PDMqa/o3qtXenD05apBG2jLgT0/BQ77d4U2UK12jWpilqMAQ==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -8208,14 +8438,15 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-			"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+			"integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
 				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"uniq": "^1.0.1",
+				"util-deprecate": "^1.0.2"
 			}
 		},
 		"postcss-svgo": {
@@ -8250,9 +8481,9 @@
 			}
 		},
 		"postcss-value-parser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-			"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 			"dev": true
 		},
 		"postcss-values-parser": {
@@ -8294,21 +8525,15 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.1.tgz",
-			"integrity": "sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
 			"dev": true
 		},
 		"pretty-bytes": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-			"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
-			"dev": true
-		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+			"integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
 			"dev": true
 		},
 		"process": {
@@ -8336,9 +8561,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
 		"pump": {
@@ -8358,9 +8583,9 @@
 			"dev": true
 		},
 		"pupa": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
-			"integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+			"integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
 			"dev": true,
 			"requires": {
 				"escape-goat": "^2.0.0"
@@ -8389,6 +8614,15 @@
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
 			"integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
 			"dev": true
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"range-parser": {
 			"version": "1.2.1",
@@ -8474,12 +8708,12 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-			"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 			"dev": true,
 			"requires": {
-				"picomatch": "^2.0.7"
+				"picomatch": "^2.2.1"
 			}
 		},
 		"recursive-readdir-sync": {
@@ -8499,9 +8733,9 @@
 			}
 		},
 		"regenerate": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
@@ -8514,19 +8748,18 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
 			"dev": true
 		},
 		"regenerator-transform": {
-			"version": "0.14.4",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
-			"integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.8.4",
-				"private": "^0.1.8"
+				"@babel/runtime": "^7.8.4"
 			}
 		},
 		"regex-not": {
@@ -8540,15 +8773,15 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-			"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-			"integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -8560,15 +8793,15 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.6.tgz",
+			"integrity": "sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -8664,11 +8897,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
 			"dev": true,
 			"requires": {
+				"is-core-module": "^2.1.0",
 				"path-parse": "^1.0.6"
 			}
 		},
@@ -8743,12 +8977,21 @@
 			}
 		},
 		"rollup": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.1.0.tgz",
-			"integrity": "sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==",
+			"version": "2.36.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
+			"integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.1.2"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"rollup-plugin-babel": {
@@ -8804,9 +9047,9 @@
 			}
 		},
 		"rollup-plugin-progress": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-progress/-/rollup-plugin-progress-1.1.1.tgz",
-			"integrity": "sha512-RIs2bnk/O2fylGN0F2w38U4PhAGIt8/N2noZ3i2tDOF0qg0PPZLKMMFp24MQUyND/w9nu61DRSanwpXOoJhxIA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-progress/-/rollup-plugin-progress-1.1.2.tgz",
+			"integrity": "sha512-6ehSZOMTZdAlRpe45kf56BnIOsDYC2GKWhGlK/Dh/Ae/AMUneMDyKdiv9ZlRrW/HVc986frTZcc2Zka+oF6W7Q==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
@@ -8850,25 +9093,25 @@
 			}
 		},
 		"rollup-plugin-serve": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-1.0.1.tgz",
-			"integrity": "sha512-bni0pb4s1YLvn1xBmj+dH1OsLdp8gWA4zqh3yuEtT6/YHhg3nDneGU2GwMcRDQwY2tXzuI0uSeAlF1rY+ODitg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-1.1.0.tgz",
+			"integrity": "sha512-pYkSsuA0/psKqhhictkJw1c2klya5b+LlCvipWqI9OE1aG2M97mRumZCbBlry5CMEOzYBBgSDgd1694sNbmyIw==",
 			"dev": true,
 			"requires": {
-				"mime": ">=2.0.3",
+				"mime": ">=2.4.6",
 				"opener": "1"
 			}
 		},
 		"rollup-plugin-terser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-			"integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz",
+			"integrity": "sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"jest-worker": "^24.9.0",
 				"rollup-pluginutils": "^2.8.2",
-				"serialize-javascript": "^2.1.2",
+				"serialize-javascript": "^4.0.0",
 				"terser": "^4.6.2"
 			}
 		},
@@ -8912,13 +9155,10 @@
 			}
 		},
 		"run-async": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-			"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-			"dev": true,
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"run-parallel": {
 			"version": "1.1.9",
@@ -8927,9 +9167,9 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-			"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+			"integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -8957,131 +9197,161 @@
 			"dev": true
 		},
 		"sass-graph": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+			"integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"lodash": "^4.0.0",
 				"scss-tokenizer": "^0.2.3",
-				"yargs": "^7.0.0"
+				"yargs": "^13.3.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
 				},
 				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
 					}
 				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "^4.1.0"
 					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
 				},
 				"wrap-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
 					}
 				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
 				"yargs": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -9114,16 +9384,22 @@
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"serialize-javascript": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -9176,9 +9452,9 @@
 			"dev": true
 		},
 		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
 		"simple-swizzle": {
@@ -9499,9 +9775,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -9540,9 +9816,9 @@
 			}
 		},
 		"spdx-correct": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -9550,15 +9826,15 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -9575,9 +9851,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
 			"dev": true
 		},
 		"spdx-ranges": {
@@ -9685,9 +9961,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -9732,24 +10008,24 @@
 				"strip-ansi": "^6.0.0"
 			}
 		},
-		"string.prototype.trimleft": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+		"string.prototype.trimend": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+			"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
-		"string.prototype.trimright": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+		"string.prototype.trimstart": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+			"integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string_decoder": {
@@ -9799,10 +10075,14 @@
 			}
 		},
 		"strip-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
-			"integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
-			"dev": true
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
+			"integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
+			"dev": true,
+			"requires": {
+				"babel-extract-comments": "^1.0.0",
+				"babel-plugin-transform-object-rest-spread": "^6.26.0"
+			}
 		},
 		"strip-indent": {
 			"version": "1.0.1",
@@ -9822,9 +10102,9 @@
 			}
 		},
 		"strip-json-comments": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
 		"stylehacks": {
@@ -10061,15 +10341,15 @@
 			}
 		},
 		"term-size": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-			"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+			"integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
 			"dev": true
 		},
 		"terser": {
-			"version": "4.6.7",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
-			"integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+			"integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -10242,15 +10522,15 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tsutils": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+			"version": "3.19.1",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.19.1.tgz",
+			"integrity": "sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -10309,34 +10589,16 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.21",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+			"version": "0.7.23",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+			"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-			"integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
-			"dev": true,
-			"requires": {
-				"commander": "~2.20.3",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
+			"version": "3.12.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.4.tgz",
+			"integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
+			"dev": true
 		},
 		"ultron": {
 			"version": "1.1.1",
@@ -10482,9 +10744,9 @@
 			"dev": true
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -10519,6 +10781,24 @@
 			"requires": {
 				"lru-cache": "4.1.x",
 				"tmp": "0.0.x"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"util": {
@@ -10554,6 +10834,27 @@
 				"es-abstract": "^1.17.2",
 				"has-symbols": "^1.0.1",
 				"object.getownpropertydescriptors": "^2.1.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"utils-merge": {
@@ -10569,9 +10870,9 @@
 			"dev": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -10629,9 +10930,9 @@
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-			"integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
 			"dev": true
 		},
 		"vscode-nls": {
@@ -10748,27 +11049,27 @@
 			"dev": true
 		},
 		"workbox-background-sync": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.1.1.tgz",
-			"integrity": "sha512-Qjitx1CxVk/gtRm7HdBj0UWnbjjpGtIxn5+ulOO4X9VAXHDLKPxrX090xihb/VRID01RgjzSPdOePdmlmA5unw==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-5.1.4.tgz",
+			"integrity": "sha512-AH6x5pYq4vwQvfRDWH+vfOePfPIYQ00nCEB7dJRU1e0n9+9HMRyvI63FlDvtFT2AvXVRsXvUt7DNMEToyJLpSA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-broadcast-update": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.1.1.tgz",
-			"integrity": "sha512-O/I4ewdWhMJ0boaMqKrZjuaYuuXB2xKo722c0SsEMDv8mB4do63LS95mrsFFR7GFUyvk/SvyvuIVz949taW1IQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-5.1.4.tgz",
+			"integrity": "sha512-HTyTWkqXvHRuqY73XrwvXPud/FN6x3ROzkfFPsRjtw/kGZuZkPzfeH531qdUGfhtwjmtO/ZzXcWErqVzJNdXaA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-build": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-5.1.1.tgz",
-			"integrity": "sha512-lwtfKIf3lSYG1q3B19fGS8wmYkoCuAZAEVDQ53nb6bBNm435GpGxuLevwTzyDMRJumrGpp2wFjHVPNTn7gw0SA==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-5.1.4.tgz",
+			"integrity": "sha512-xUcZn6SYU8usjOlfLb9Y2/f86Gdo+fy1fXgH8tJHjxgpo53VVsqRX0lUDw8/JuyzNmXuo8vXX14pXX2oIm9Bow==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.8.4",
@@ -10786,27 +11087,27 @@
 				"pretty-bytes": "^5.3.0",
 				"rollup": "^1.31.1",
 				"rollup-plugin-babel": "^4.3.3",
-				"rollup-plugin-terser": "^5.2.0",
+				"rollup-plugin-terser": "^5.3.1",
 				"source-map": "^0.7.3",
 				"source-map-url": "^0.4.0",
 				"stringify-object": "^3.3.0",
-				"strip-comments": "^2.0.1",
+				"strip-comments": "^1.0.2",
 				"tempy": "^0.3.0",
 				"upath": "^1.2.0",
-				"workbox-background-sync": "^5.1.1",
-				"workbox-broadcast-update": "^5.1.1",
-				"workbox-cacheable-response": "^5.1.1",
-				"workbox-core": "^5.1.1",
-				"workbox-expiration": "^5.1.1",
-				"workbox-google-analytics": "^5.1.1",
-				"workbox-navigation-preload": "^5.1.1",
-				"workbox-precaching": "^5.1.1",
-				"workbox-range-requests": "^5.1.1",
-				"workbox-routing": "^5.1.1",
-				"workbox-strategies": "^5.1.1",
-				"workbox-streams": "^5.1.1",
-				"workbox-sw": "^5.1.1",
-				"workbox-window": "^5.1.1"
+				"workbox-background-sync": "^5.1.4",
+				"workbox-broadcast-update": "^5.1.4",
+				"workbox-cacheable-response": "^5.1.4",
+				"workbox-core": "^5.1.4",
+				"workbox-expiration": "^5.1.4",
+				"workbox-google-analytics": "^5.1.4",
+				"workbox-navigation-preload": "^5.1.4",
+				"workbox-precaching": "^5.1.4",
+				"workbox-range-requests": "^5.1.4",
+				"workbox-routing": "^5.1.4",
+				"workbox-strategies": "^5.1.4",
+				"workbox-streams": "^5.1.4",
+				"workbox-sw": "^5.1.4",
+				"workbox-window": "^5.1.4"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -10855,110 +11156,110 @@
 			}
 		},
 		"workbox-cacheable-response": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.1.1.tgz",
-			"integrity": "sha512-g5yU0zq5G5491SjcN/7pIMjyDvTkZV9aKWGWPVGUWHmRg7rTpb41ZT+33TvpHDkId6/wKjtlRtaZ7Ftl24oAng==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-5.1.4.tgz",
+			"integrity": "sha512-0bfvMZs0Of1S5cdswfQK0BXt6ulU5kVD4lwer2CeI+03czHprXR3V4Y8lPTooamn7eHP8Iywi5QjyAMjw0qauA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-core": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.1.1.tgz",
-			"integrity": "sha512-9eP2SecpDpcs+8ZDja0fYx4IJV9+G5qa+q5/kheaxFY6sYlGjOVf+v7JaAVXeZmUSCTOwHY3qRFA4P5WU4vjCw==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-5.1.4.tgz",
+			"integrity": "sha512-+4iRQan/1D8I81nR2L5vcbaaFskZC2CL17TLbvWVzQ4qiF/ytOGF6XeV54pVxAvKUtkLANhk8TyIUMtiMw2oDg==",
 			"dev": true
 		},
 		"workbox-expiration": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.1.1.tgz",
-			"integrity": "sha512-JkCWtY2HIWw8SA7xfDq7lD0SzL0qy8a8QXC6hGHRMgMbzWUWYASGXVyqwTY2IUn5Hm7u58xO9LQTNbBYDSD0Ww==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-5.1.4.tgz",
+			"integrity": "sha512-oDO/5iC65h2Eq7jctAv858W2+CeRW5e0jZBMNRXpzp0ZPvuT6GblUiHnAsC5W5lANs1QS9atVOm4ifrBiYY7AQ==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-google-analytics": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.1.1.tgz",
-			"integrity": "sha512-T9rcOjbNb8USFXXWSgRIt3+1QWoGSUw1gmOCC34rWAF/QMKn+EQomApVg6ixY61jGsYQ7Kwgjgtk0DBP5iZsFQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-5.1.4.tgz",
+			"integrity": "sha512-0IFhKoEVrreHpKgcOoddV+oIaVXBFKXUzJVBI+nb0bxmcwYuZMdteBTp8AEDJacENtc9xbR0wa9RDCnYsCDLjA==",
 			"dev": true,
 			"requires": {
-				"workbox-background-sync": "^5.1.1",
-				"workbox-core": "^5.1.1",
-				"workbox-routing": "^5.1.1",
-				"workbox-strategies": "^5.1.1"
+				"workbox-background-sync": "^5.1.4",
+				"workbox-core": "^5.1.4",
+				"workbox-routing": "^5.1.4",
+				"workbox-strategies": "^5.1.4"
 			}
 		},
 		"workbox-navigation-preload": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.1.1.tgz",
-			"integrity": "sha512-g3S4NK/Leor4p1rXS4UBGCN//ZJ7Tva7Q4sOj33qeDqfVQiXsd1P+q7BUk87Zdbld5e/ijtxtMRlJ0iVlJlWfw==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-5.1.4.tgz",
+			"integrity": "sha512-Wf03osvK0wTflAfKXba//QmWC5BIaIZARU03JIhAEO2wSB2BDROWI8Q/zmianf54kdV7e1eLaIEZhth4K4MyfQ==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-precaching": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.1.1.tgz",
-			"integrity": "sha512-fpsN5/EuRyADpqdgcZ+0PiympjK4qBf+emNOp25+TvO0KQ6/uq+W/18pFIR3rX9OPwMzptvg3ZQimW/xtyeaQg==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-5.1.4.tgz",
+			"integrity": "sha512-gCIFrBXmVQLFwvAzuGLCmkUYGVhBb7D1k/IL7pUJUO5xacjLcFUaLnnsoVepBGAiKw34HU1y/YuqvTKim9qAZA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-range-requests": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.1.1.tgz",
-			"integrity": "sha512-VYWjIIhEudR+76+73DOfeLZyxknw0MjWJKnVYC0rvsOdoqrpWPxLAtHzl+f1PE6VGpoW6XtyXOVSIeCscbqdpw==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-5.1.4.tgz",
+			"integrity": "sha512-1HSujLjgTeoxHrMR2muDW2dKdxqCGMc1KbeyGcmjZZAizJTFwu7CWLDmLv6O1ceWYrhfuLFJO+umYMddk2XMhw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-routing": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.1.1.tgz",
-			"integrity": "sha512-RcDs+LehpyXs1GA3Kh6DsmSN/gDKr1QjeVwMWBchz3rwDxdM/E7HSpqhL76lYYif7OmQUso36NPWG3zik/J16A==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-5.1.4.tgz",
+			"integrity": "sha512-8ljknRfqE1vEQtnMtzfksL+UXO822jJlHTIR7+BtJuxQ17+WPZfsHqvk1ynR/v0EHik4x2+826Hkwpgh4GKDCw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"workbox-strategies": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.1.1.tgz",
-			"integrity": "sha512-w7GmrkIYGyJWgqYOayPzSI1k/wildb5uynDWGrwIvbKFCtUaaxuzdBOhrsFhjERIFHtB/42BSbVAk3Scnmvxvg==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-5.1.4.tgz",
+			"integrity": "sha512-VVS57LpaJTdjW3RgZvPwX0NlhNmscR7OQ9bP+N/34cYMDzXLyA6kqWffP6QKXSkca1OFo/v6v7hW7zrrguo6EA==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1",
-				"workbox-routing": "^5.1.1"
+				"workbox-core": "^5.1.4",
+				"workbox-routing": "^5.1.4"
 			}
 		},
 		"workbox-streams": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.1.1.tgz",
-			"integrity": "sha512-O43hEsUfiZxdn9i9x5OCTKIwG6HMs5uwzmGv3vk2xOEe/7GGAv6AxlsFu75cIaMGB7RdlMpt0GdIWbenv1Loxw==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-5.1.4.tgz",
+			"integrity": "sha512-xU8yuF1hI/XcVhJUAfbQLa1guQUhdLMPQJkdT0kn6HP5CwiPOGiXnSFq80rAG4b1kJUChQQIGPrq439FQUNVrw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1",
-				"workbox-routing": "^5.1.1"
+				"workbox-core": "^5.1.4",
+				"workbox-routing": "^5.1.4"
 			}
 		},
 		"workbox-sw": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.1.1.tgz",
-			"integrity": "sha512-v6wS7vKgPzyUCwX1fw4fMNhV8mxEyb0acy/naxtRzSjVkYhs8iHRAJfuuHlmVXEcsNn9+6b/um7S50h2zvtHXQ==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-5.1.4.tgz",
+			"integrity": "sha512-9xKnKw95aXwSNc8kk8gki4HU0g0W6KXu+xks7wFuC7h0sembFnTrKtckqZxbSod41TDaGh+gWUA5IRXrL0ECRA==",
 			"dev": true
 		},
 		"workbox-window": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.1.1.tgz",
-			"integrity": "sha512-/9WPtkrxM6DI6mbTvz3fFac57SuxuG5QwwEZHct1C+kGfUfpU5LvS+zzQgBOZSQeJZfRbUPH0kTR66uM+x10Ww==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-5.1.4.tgz",
+			"integrity": "sha512-vXQtgTeMCUq/4pBWMfQX8Ee7N2wVC4Q7XYFqLnfbXJ2hqew/cU1uMTD2KqGEgEpE4/30luxIxgE+LkIa8glBYw==",
 			"dev": true,
 			"requires": {
-				"workbox-core": "^5.1.1"
+				"workbox-core": "^5.1.4"
 			}
 		},
 		"wrap-ansi": {
@@ -11017,9 +11318,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yargs": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	},
 	"devDependencies": {
 		"@appnest/readme": "^1.2.7",
-		"@appnest/web-config": "0.5.0",
+		"@appnest/web-config": "^0.5.0",
 		"lit-element": "^2.3.1",
 		"node-typescript-compiler": "^2.1.1",
 		"weightless": "0.0.37"


### PR DESCRIPTION
There's an issue with with node14 and `rollup-plugin-progress`, one of the dependencies of `@appnest/web-config`. This PR updates `@appnest/web-config` with the updated dependencies.

More info: https://github.com/jkuri/rollup-plugin-progress/pull/18