### PR TITLE
Don't change anchor links to use the history API if the router doesn't have a match

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Go [`here`](https://developer.mozilla.org/en-US/docs/Web/API/History) to read mo
 
 #### Anchor element
 
-Normally an [`anchor element`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) reloads the page when clicked. This library however changes the default behavior of all anchor element to use the history API instead.
+Normally an [`anchor element`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) reloads the page when clicked. This library however changes the default behavior of all anchor element to use the history API if the router supports the route.
 
 ```html
 <a href="/home">Go to home!</a>

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -11,6 +11,8 @@ export interface IRouterSlot<D = any, P = any> extends HTMLElement {
 	constructAbsolutePath: ((path: PathFragment) => string);
 	parent: IRouterSlot<P> | null | undefined;
 	queryParentRouterSlot: (() => IRouterSlot<P> | null);
+	// Return the matched route if one found for the given path
+	getRouteMatch(path: string | PathFragment): IRouteMatch<D> | null;
 }
 
 export type IRoutingInfo<D = any, P = any> = {

--- a/src/lib/router-slot.ts
+++ b/src/lib/router-slot.ts
@@ -196,6 +196,10 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	 * Attach the anchor listener
 	 */
 	protected setupAnchorListener(): void {
+		// only bind the AnchorHandler to the root router
+		// otherwise, we get multiple click handlers,
+		// each responding to a different router
+		if (!this.isRoot) return;
 		this.anchorHandler = new AnchorHandler(this);
 		this.anchorHandler?.setup();
 	}

--- a/src/lib/router-slot.ts
+++ b/src/lib/router-slot.ts
@@ -160,6 +160,15 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	}
 
 	/**
+	 * Return a route match for a given path or null if there's no match
+	 * @param path
+	 */
+	getRouteMatch(path: string | PathFragment): IRouteMatch<D> | null {
+		const match = matchRoutes(this._routes, path);
+		return match;
+	}
+
+	/**
 	 * Each time the path changes, load the new path.
 	 */
 	async render (): Promise<void> {
@@ -226,11 +235,6 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	 */
 	protected detachListeners (): void {
 		removeListeners(this.listeners);
-	}
-
-	getRouteMatch(path: string | PathFragment): IRouteMatch<D> | null {
-		const match = matchRoutes(this._routes, path);
-		return match;
 	}
 
 	/**

--- a/src/lib/router-slot.ts
+++ b/src/lib/router-slot.ts
@@ -1,6 +1,6 @@
 import { GLOBAL_ROUTER_EVENTS_TARGET, ROUTER_SLOT_TAG_NAME } from "./config";
 import { Cancel, EventListenerSubscription, GlobalRouterEvent, IPathFragments, IRoute, IRouteMatch, IRouterSlot, IRoutingInfo, Params, PathFragment, RouterSlotEvent } from "./model";
-import { addListener, AnchorHandler, constructAbsolutePath, dispatchGlobalRouterEvent, dispatchRouteChangeEvent, ensureHistoryEvents, handleRedirect, isRedirectRoute, isResolverRoute, matchRoutes, pathWithoutBasePath, queryParentRouterSlot, removeListeners, resolvePageComponent, shouldNavigate } from "./util";
+import { addListener, AnchorHandler, constructAbsolutePath, dispatchGlobalRouterEvent, dispatchRouteChangeEvent, ensureHistoryEvents, handleRedirect, IAnchorHandler, isRedirectRoute, isResolverRoute, matchRoutes, pathWithoutBasePath, queryParentRouterSlot, removeListeners, resolvePageComponent, shouldNavigate } from "./util";
 
 const template = document.createElement("template");
 template.innerHTML = `<slot></slot>`;
@@ -89,7 +89,7 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	/**
 	 * The anchor link handler for the router slot
 	 */
-	private anchorHandler?: AnchorHandler;
+	private anchorHandler?: IAnchorHandler;
 
 	/**
 	 * Hooks up the element.
@@ -188,19 +188,11 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	 */
 	protected setupAnchorListener(): void {
 		this.anchorHandler = new AnchorHandler(this);
-		window.addEventListener(
-			'click',
-			this.anchorHandler?.handleEvent.bind(this)
-		);
+		this.anchorHandler?.setup();
 	}
 
 	protected detachAnchorListener(): void {
-		if (this.anchorHandler) {
-			window.removeEventListener(
-				'click',
-				this.anchorHandler.handleEvent
-			);
-		}
+		this.anchorHandler?.teardown();
 	}
 
 	/**

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -52,7 +52,17 @@ export class AnchorHandler implements IAnchorHandler {
 		// - 4. The router can handle the route
 		const routeMatched = this.routerSlot?.getRouteMatch($anchor.pathname);
 
-		if (!hrefIsRelative || differentFrameTargetted || isDisabled || !routeMatched) {
+		// - 5. User is not holding down metaKey (Command on Mac, Control on Windows)
+		//      which is typically used to open a new tab.
+		const userIsHoldingMetaKey = e.metaKey;
+
+		if (
+			!hrefIsRelative ||
+			differentFrameTargetted ||
+			isDisabled ||
+			!routeMatched ||
+			userIsHoldingMetaKey
+		) {
 			return;
 		}
 

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -52,7 +52,7 @@ export class AnchorHandler implements IAnchorHandler {
 		// - 4. The router can handle the route
 		const routeMatched = this.routerSlot?.getRouteMatch($anchor.pathname);
 
-		// - 5. User is not holding down metaKey (Command on Mac, Control on Windows)
+		// - 5. User is not holding down the meta key, (Command on Mac, Control on Windows)
 		//      which is typically used to open a new tab.
 		const userIsHoldingMetaKey = e.metaKey;
 

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -17,20 +17,24 @@ export class AnchorHandler implements IAnchorHandler {
 	}
 
 	setup(): void {
+		// store a reference to the bound event handler so we can unbind later
+		this.boundEventHandler = this.handleEvent.bind(this);
 		window.addEventListener(
 			'click',
-			(e) => this.handleEvent(e)
+			this.boundEventHandler
 		);
 	}
 
 	teardown(): void {
 		window.removeEventListener(
 			'click',
-			(e) => this.handleEvent(e)
+			this.boundEventHandler
 		);
 	}
 
-	private handleEvent(e: MouseEvent) {
+	private boundEventHandler?: any;
+
+	private handleEvent(e: MouseEvent): void {
 		// Find the target by using the composed path to get the element through the shadow boundaries.
 		const $anchor = ("composedPath" in e as any) ? e.composedPath().find($elem => $elem instanceof HTMLAnchorElement) : e.target;
 

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -1,9 +1,17 @@
+import { IRouterSlot } from "../model";
+
 /**
- * Hook up a click listener to the window that, for all anchor tags
- * that has a relative HREF, uses the history API instead.
+ * The AnchorHandler allows the RouterSlot to observe all anchor clicks
+ * and either handle the click or let the browser handle it.
  */
-export function ensureAnchorHistory () {
-	window.addEventListener("click", (e: MouseEvent) => {
+export class AnchorHandler {
+	routerSlot?: IRouterSlot;
+
+	constructor(routerSlot?: IRouterSlot) {
+		this.routerSlot = routerSlot;
+	}
+
+	handleEvent(e: MouseEvent) {
 		// Find the target by using the composed path to get the element through the shadow boundaries.
 		const $anchor = ("composedPath" in e as any) ? e.composedPath().find($elem => $elem instanceof HTMLAnchorElement) : e.target;
 
@@ -12,16 +20,20 @@ export function ensureAnchorHistory () {
 			return;
 		}
 
-		// Get the HREF value from the anchor tag
-		const href = $anchor.href;
-
 		// Only handle the anchor tag if the follow holds true:
-		// - The HREF is relative to the origin of the current location.
-		// - The target is targeting the current frame.
-		// - The anchor doesn't have the attribute [data-router-slot]="disabled"
-		if (!href.startsWith(location.origin) ||
-		   ($anchor.target !== "" && $anchor.target !== "_self") ||
-		   $anchor.dataset["routerSlot"] === "disabled") {
+		// - 1. The HREF is relative to the origin of the current location.
+		const hrefIsRelative = $anchor.href.startsWith(location.origin);
+
+		// - 2. The target is targeting the current frame.
+		const differentFrameTargetted = $anchor.target !== "" && $anchor.target !== "_self";
+
+		// - 3. The anchor doesn't have the attribute [data-router-slot]="disabled"
+		const isDisabled = $anchor.dataset["routerSlot"] === "disabled";
+
+		// - 4. The router can handle the route
+		const routeMatched = this.routerSlot?.getRouteMatch($anchor.pathname);
+
+		if (!hrefIsRelative || differentFrameTargetted || isDisabled || !routeMatched) {
 			return;
 		}
 
@@ -39,5 +51,5 @@ export function ensureAnchorHistory () {
 
 		// Change the history!
 		history.pushState(null, "", path);
-	});
+	}
 }

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -1,17 +1,36 @@
-import { IRouterSlot } from "../model";
+import type { IRouterSlot } from "../model";
+
+export interface IAnchorHandler {
+	setup(): void;
+	teardown(): void;
+}
 
 /**
  * The AnchorHandler allows the RouterSlot to observe all anchor clicks
  * and either handle the click or let the browser handle it.
  */
-export class AnchorHandler {
+export class AnchorHandler implements IAnchorHandler {
 	routerSlot?: IRouterSlot;
 
 	constructor(routerSlot?: IRouterSlot) {
 		this.routerSlot = routerSlot;
 	}
 
-	handleEvent(e: MouseEvent) {
+	setup(): void {
+		window.addEventListener(
+			'click',
+			(e) => this.handleEvent(e)
+		);
+	}
+
+	teardown(): void {
+		window.removeEventListener(
+			'click',
+			(e) => this.handleEvent(e)
+		);
+	}
+
+	private handleEvent(e: MouseEvent) {
 		// Find the target by using the composed path to get the element through the shadow boundaries.
 		const $anchor = ("composedPath" in e as any) ? e.composedPath().find($elem => $elem instanceof HTMLAnchorElement) : e.target;
 

--- a/src/test/anchor.test.ts
+++ b/src/test/anchor.test.ts
@@ -10,7 +10,7 @@ describe("AnchorHandler", () => {
 	let $anchor!: HTMLAnchorElement;
 	let $slot = new RouterSlot();
 	let $anchorHandler = new AnchorHandler($slot);
-	let $windowPushstateCallbackHandler: () => void;
+	let $windowPushstateHandler: () => void;
 
 	const addTestRoute = () => {
 		$slot.add([
@@ -35,7 +35,7 @@ describe("AnchorHandler", () => {
 	});
 	afterEach(() => {
 		$slot.clear();
-		window.removeEventListener('pushstate', $windowPushstateCallbackHandler);
+		window.removeEventListener('pushstate', $windowPushstateHandler);
 	});
 	after(() => {
 		clearHistory();
@@ -45,12 +45,12 @@ describe("AnchorHandler", () => {
 	it("[AnchorHandler] should change anchors to use history API", done => {
 		addTestRoute();
 
-		$windowPushstateCallbackHandler = () => {
+		$windowPushstateHandler = () => {
 			expect(path({end: false})).to.equal(testPath);
 			done();
 		};
 
-		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
+		window.addEventListener("pushstate", $windowPushstateHandler);
 
 		$anchor.click();
 	});
@@ -58,11 +58,11 @@ describe("AnchorHandler", () => {
 	it("[AnchorHandler] should not change anchors with target _blank", done => {
 		addTestRoute();
 
-		$windowPushstateCallbackHandler = () => {
+		$windowPushstateHandler = () => {
 			expect(true).to.equal(false);
 		}
 
-		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
+		window.addEventListener("pushstate", $windowPushstateHandler);
 
 		$anchor.target = "_blank";
 		$anchor.click();
@@ -72,11 +72,11 @@ describe("AnchorHandler", () => {
 	it("[AnchorHandler] should not change anchors with [data-router-slot]='disabled'", done => {
 		addTestRoute();
 
-		$windowPushstateCallbackHandler = () => {
+		$windowPushstateHandler = () => {
 			expect(true).to.equal(false);
 		}
 
-		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
+		window.addEventListener("pushstate", $windowPushstateHandler);
 
 		$anchor.setAttribute("data-router-slot", "disabled");
 		$anchor.click();
@@ -87,11 +87,11 @@ describe("AnchorHandler", () => {
 		// there are no routes added to the $slot in this test
 		// so the router will not attempt to handle it
 
-		$windowPushstateCallbackHandler = () => {
+		$windowPushstateHandler = () => {
 			expect(true).to.equal(false);
 		}
 
-		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
+		window.addEventListener("pushstate", $windowPushstateHandler);
 
 		$anchor.click();
 		done();
@@ -105,11 +105,11 @@ describe("AnchorHandler", () => {
 			}
 		]);
 
-		$windowPushstateCallbackHandler = () => {
+		$windowPushstateHandler = () => {
 			expect(path({ end: false })).to.equal(testPath);
 			done();
 		}
-		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
+		window.addEventListener("pushstate", $windowPushstateHandler);
 
 		$anchor.click();
 	});

--- a/src/test/anchor.test.ts
+++ b/src/test/anchor.test.ts
@@ -10,12 +10,12 @@ describe("AnchorHandler", () => {
 	let $anchor!: HTMLAnchorElement;
 	let $slot = new RouterSlot();
 	let $anchorHandler = new AnchorHandler($slot);
+	let $windowPushstateCallbackHandler: () => void;
 
 	const addTestRoute = () => {
 		$slot.add([
 			{
 				path: testPath,
-				pathMatch: "suffix",
 				component: () => document.createElement("div")
 			}
 		])
@@ -35,6 +35,7 @@ describe("AnchorHandler", () => {
 	});
 	afterEach(() => {
 		$slot.clear();
+		window.removeEventListener('pushstate', $windowPushstateCallbackHandler);
 	});
 	after(() => {
 		clearHistory();
@@ -44,10 +45,12 @@ describe("AnchorHandler", () => {
 	it("[AnchorHandler] should change anchors to use history API", done => {
 		addTestRoute();
 
-		window.addEventListener("pushstate", () => {
+		$windowPushstateCallbackHandler = () => {
 			expect(path({end: false})).to.equal(testPath);
 			done();
-		});
+		};
+
+		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
 
 		$anchor.click();
 	});
@@ -55,9 +58,11 @@ describe("AnchorHandler", () => {
 	it("[AnchorHandler] should not change anchors with target _blank", done => {
 		addTestRoute();
 
-		window.addEventListener("pushstate", () => {
+		$windowPushstateCallbackHandler = () => {
 			expect(true).to.equal(false);
-		});
+		}
+
+		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
 
 		$anchor.target = "_blank";
 		$anchor.click();
@@ -67,9 +72,11 @@ describe("AnchorHandler", () => {
 	it("[AnchorHandler] should not change anchors with [data-router-slot]='disabled'", done => {
 		addTestRoute();
 
-		window.addEventListener("pushstate", () => {
+		$windowPushstateCallbackHandler = () => {
 			expect(true).to.equal(false);
-		});
+		}
+
+		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
 
 		$anchor.setAttribute("data-router-slot", "disabled");
 		$anchor.click();
@@ -80,11 +87,30 @@ describe("AnchorHandler", () => {
 		// there are no routes added to the $slot in this test
 		// so the router will not attempt to handle it
 
-		window.addEventListener("pushstate", () => {
+		$windowPushstateCallbackHandler = () => {
 			expect(true).to.equal(false);
-		});
+		}
+
+		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
 
 		$anchor.click();
 		done();
+	});
+
+	it("[AnchorHandler] should change anchors if there is a catch-all route", done => {
+		$slot.add([
+			{
+				path: '**',
+				component: () => document.createElement("div")
+			}
+		]);
+
+		$windowPushstateCallbackHandler = () => {
+			expect(path({ end: false })).to.equal(testPath);
+			done();
+		}
+		window.addEventListener("pushstate", $windowPushstateCallbackHandler);
+
+		$anchor.click();
 	});
 });


### PR DESCRIPTION
The use case for this is integrating `router-slot` into a server-side routed web app where we're proxy-passing from the same parent URL. ie: `foo.com/about` and `foo.com/products` where `/about` is using `router-slot`, but `/products` is not. Anchor links to `/products` will currently try to be handled by `router-slot` because it's a relative link, even if you don't have a route for it.

With this change, if you don't have a catch-all route in `router-slot`, it will allow the browser to redirect the link to the server-side routed `/products` URL.

If the app has a catch-all route, it will still be handled client-side.