### PR TITLE
Fix `full` path match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@internetarchive/router-slot",
-	"version": "1.5.6-1",
+	"version": "1.5.7-0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@internetarchive/router-slot",
-	"version": "1.5.5-0",
+	"version": "1.5.6-0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@internetarchive/router-slot",
-	"version": "1.5.6-0",
+	"version": "1.5.6-1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
 		"b:lib": "node pre-build.js && tsc -p tsconfig.build.json && npm run custom-elements-json",
 		"readme": "node node_modules/.bin/readme generate",
 		"postversion": "npm run readme && npm run b:lib",
-		"publish:patch": "np patch --contents=dist --no-cleanup",
-		"publish:minor": "np minor --contents=dist --no-cleanup",
-		"publish:major": "np major --contents=dist --no-cleanup",
+		"publish:prepatch": "npx np prepatch --tag=canary --any-branch --contents=dist --no-cleanup",
+		"publish:patch": "npx np patch --contents=dist --no-cleanup",
+		"publish:minor": "npx np minor --contents=dist --no-cleanup",
+		"publish:major": "npx np major --contents=dist --no-cleanup",
 		"custom-elements-json": "npx wca analyze src/lib --format json --outFile dist/custom-elements.json"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@internetarchive/router-slot",
-	"version": "1.5.5-0",
+	"version": "1.5.6-0",
 	"description": "A powerful web component router",
 	"license": "MIT",
 	"author": "Andreas Mehlsen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@internetarchive/router-slot",
-	"version": "1.5.6-1",
+	"version": "1.5.7-0",
 	"description": "A powerful web component router",
 	"license": "MIT",
 	"author": "Andreas Mehlsen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@internetarchive/router-slot",
-	"version": "1.5.6-0",
+	"version": "1.5.6-1",
 	"description": "A powerful web component router",
 	"license": "MIT",
 	"author": "Andreas Mehlsen",

--- a/src/lib/util/router.ts
+++ b/src/lib/util/router.ts
@@ -47,7 +47,7 @@ export function matchRoute<D = any> (route: IRoute<D>, path: string | PathFragme
 	// All matches starts with ^ to make sure the match is done from the beginning of the path.
 	const regex = route.path === CATCH_ALL_WILDCARD || (route.path.length === 0 && route.pathMatch != "full" ) ? /^/ : (() => {
 		switch (route.pathMatch || DEFAULT_PATH_MATCH) {
-			case "full": return new RegExp(`^${routePath}\/?$`);
+			case "full": return new RegExp(`^\/?${routePath}\/?$`);
 			case "suffix": return new RegExp(`^.*?${routePath}\/?$`);
 			case "fuzzy": return new RegExp(`^.*?${routePath}.*?$`);
 			case "prefix": default: return new RegExp(`^[\/]?${routePath}(?:\/|$)`);


### PR DESCRIPTION
This adds an optional forward slash to the beginning of the `full` regex match. The path always seems to come through with a preceding forward slash so there was no way to match a `full` path without this.